### PR TITLE
fix: Obsidian vault path via env var + utilitaire Linear team UUID

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,8 +31,11 @@ APALEO_CLIENT_SECRET=...
 # Windows native path:  C:/Users/IVAN/OneDrive/Documents/Agentic AI Hospitality
 # WSL mount path:       /mnt/c/Users/IVAN/OneDrive/Documents/Agentic AI Hospitality
 # Docker bind-mount:    set to the path inside the container (e.g. /vault)
-OBSIDIAN_VAULT_PATH=C:/Users/IVAN/OneDrive/Documents/Agentic AI Hospitality
+# scripts/intelligence_report.py reads this variable — required on Linux/WSL/CI
+OBSIDIAN_VAULT_PATH=/mnt/c/Users/IVAN/OneDrive/Documents/Agentic AI Hospitality
 
 # Linear (issue & task tracking)
+# IMPORTANT: LINEAR_TEAM_ID doit être l'UUID de l'équipe HOS (pas TAC).
+# Pour obtenir l'UUID correct : python scripts/linear_teams.py
 LINEAR_API_KEY=lin_api_...
-LINEAR_TEAM_ID=...
+LINEAR_TEAM_ID=<UUID équipe HOS — obtenir via: python scripts/linear_teams.py>

--- a/scripts/intelligence_report.py
+++ b/scripts/intelligence_report.py
@@ -48,7 +48,14 @@ import httpx
 # ─── Configuration ────────────────────────────────────────────────────────────
 
 REPO_ROOT  = Path(__file__).parent.parent.resolve()
-VAULT_ROOT = Path(r"C:\Users\IVAN\OneDrive\Documents\Agentic AI Hospitality")
+
+# Vault path: use OBSIDIAN_VAULT_PATH env var (supports WSL, Linux, CI).
+# Fallback to the Windows path for local native dev.
+_vault_env = os.environ.get(
+    "OBSIDIAN_VAULT_PATH",
+    r"C:\Users\IVAN\OneDrive\Documents\Agentic AI Hospitality",
+)
+VAULT_ROOT = Path(_vault_env)
 VAULT_INTEL_DIR = VAULT_ROOT / "AI Reports" / "Intelligence"
 
 LINEAR_API = "https://api.linear.app/graphql"

--- a/scripts/linear_teams.py
+++ b/scripts/linear_teams.py
@@ -1,0 +1,68 @@
+"""
+scripts/linear_teams.py
+Liste toutes les équipes Linear et leurs UUIDs.
+
+Usage :
+    LINEAR_API_KEY=lin_api_... python scripts/linear_teams.py
+
+Copier l'UUID de l'équipe HOS dans LINEAR_TEAM_ID (.env + GitHub Secrets).
+"""
+
+import os
+import sys
+import httpx
+
+LINEAR_API = "https://api.linear.app/graphql"
+
+QUERY = """
+query {
+  teams {
+    nodes {
+      id
+      name
+      key
+    }
+  }
+}
+"""
+
+
+def main() -> None:
+    api_key = os.environ.get("LINEAR_API_KEY", "")
+    if not api_key:
+        print("Erreur : LINEAR_API_KEY non définie", file=sys.stderr)
+        sys.exit(1)
+
+    resp = httpx.post(
+        LINEAR_API,
+        headers={"Authorization": api_key, "Content-Type": "application/json"},
+        json={"query": QUERY},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    teams = data.get("data", {}).get("teams", {}).get("nodes", [])
+    if not teams:
+        print("Aucune équipe trouvée.")
+        return
+
+    print(f"\n{'Clé':<8} {'Nom':<30} {'UUID'}")
+    print("─" * 75)
+    for t in teams:
+        marker = " ◄ utiliser cet UUID" if t["key"] == "HOS" else ""
+        print(f"{t['key']:<8} {t['name']:<30} {t['id']}{marker}")
+
+    print()
+    hos = next((t for t in teams if t["key"] == "HOS"), None)
+    if hos:
+        print(f"LINEAR_TEAM_ID={hos['id']}")
+        print("\nMettre à jour :")
+        print("  1. .env local")
+        print("  2. GitHub → Settings → Secrets → LINEAR_TEAM_ID")
+    else:
+        print("Équipe HOS non trouvée. Vérifier le nom de l'équipe dans Linear.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- intelligence_report.py : VAULT_ROOT lit OBSIDIAN_VAULT_PATH (env var) au lieu du chemin Windows hardcodé — corrige l'inaccessibilité du vault en environnement Linux/WSL/CI
- scripts/linear_teams.py : nouveau script pour lister les équipes Linear et identifier l'UUID correct (HOS vs TAC)
- backend/.env.example : OBSIDIAN_VAULT_PATH mis à jour vers le chemin WSL
  + note sur LINEAR_TEAM_ID (doit pointer sur HOS, pas TAC)

https://claude.ai/code/session_01QyxT7tosiGbkZFkcy73Cv9