### PR TITLE
fix: restore CaptationBaseline model and baselines router lost in PR …

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -85,6 +85,41 @@ class PMSSyncLog(Base):
     
     created_at = Column(DateTime, default=datetime.utcnow)
 
+class CaptationBaseline(Base):
+    """
+    Stores calculated captation rate baselines per tenant/property.
+    Story 2.4: Calculate Baseline Captation Rates (FR3).
+
+    Captation rate = F&B revenue per occupied room.
+    Adjustment factors normalise the baseline by day-of-week and month
+    so that Story 3.3a can detect anomalies relative to the expected pattern.
+    """
+    __tablename__ = "captation_baselines"
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(String, ForeignKey("restaurant_profiles.tenant_id"), index=True, nullable=False)
+
+    # Date range of PMSSyncLog data used for this computation
+    period_start = Column(Date, nullable=False)
+    period_end = Column(Date, nullable=False)
+
+    # Core metric: average F&B revenue per occupied room across all data
+    avg_fb_revenue_per_room = Column(Float, nullable=False)
+
+    # Day-of-week factors (JSON): {"0": 1.05, "1": 0.98, ...} (0=Monday … 6=Sunday)
+    # Each value is the ratio of that weekday's avg captation rate to the overall avg.
+    dow_factors = Column(JSON, nullable=False)
+
+    # Monthly factors (JSON): {"1": 0.90, "2": 0.85, ..., "12": 1.10}
+    # Each value is the ratio of that month's avg captation rate to the overall avg.
+    monthly_factors = Column(JSON, nullable=False)
+
+    # Number of non-zero occupancy records used in the computation
+    data_points_count = Column(Integer, nullable=False)
+
+    computed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 class WeatherForecast(Base):
     """
     Normalized weather forecast records ingested from Open-Meteo.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.error_handlers import problem_details_handler
-from app.api.routes import pms, webhooks, auth, dashboard, predictions, reports, weather
+from app.api.routes import pms, webhooks, auth, dashboard, predictions, reports, weather, baselines
 from app.db.models import Base
 from app.db.session import engine
 from app.workers.weather_sync import start_weather_scheduler, stop_weather_scheduler
@@ -48,6 +48,7 @@ app.include_router(auth.router, prefix="/api/v1")
 app.include_router(dashboard.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
 app.include_router(weather.router, prefix="/api/v1")
+app.include_router(baselines.router, prefix="/api/v1")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…#13 merge conflict

During conflict resolution on GitHub (PR #13 vs main), "Accept incoming change" was chosen for models.py and main.py, which kept the WeatherForecast additions but dropped CaptationBaseline (from PR #12) and the /baselines router registration.

- backend/app/db/models.py: re-add CaptationBaseline model (captation_baselines table)
- backend/app/main.py: re-add baselines router import and include_router call

https://claude.ai/code/session_01JJReLKzsycVWDDgANd6Mt6