### PR TITLE
feat(HOS-84): implement PredictHQ event ingestion (Story 3.2)

### DIFF
--- a/backend/app/api/routes/events.py
+++ b/backend/app/api/routes/events.py
@@ -1,0 +1,104 @@
+"""Events sync endpoint — HOS-84 Story 3.2.
+
+POST /api/v1/events/sync
+  → 202 Accepted immediately (BackgroundTasks pattern)
+  → Background task calls EventIngestionService.sync_for_tenant
+
+Architecture constraints:
+- Fat Backend: no PredictHQ calls from Next.js.
+- RFC 7807 error format via problem_details_handler (registered in main.py).
+- camelCase output via Pydantic alias generator on response model.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.core.security import get_current_user
+from app.db.models import RestaurantProfile
+from app.db.session import AsyncSessionLocal, get_db
+from app.schemas.events import EventSyncRequest, EventSyncResponse
+from app.services.event_ingestion import EventIngestionService
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+async def _background_sync(tenant_id: str, radius_km: float, days_ahead: int) -> None:
+    """Run event sync in a fire-and-forget background task."""
+    service = EventIngestionService()
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(RestaurantProfile).where(RestaurantProfile.tenant_id == tenant_id)
+        )
+        profile = result.scalars().first()
+        if profile is None:
+            return
+        try:
+            await service.sync_for_tenant(session, profile, radius_km=radius_km, days_ahead=days_ahead)
+        except Exception:  # noqa: BLE001
+            # Logged inside service; do not propagate out of background task
+            pass
+
+
+@router.post(
+    "/sync",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=EventSyncResponse,
+    summary="Trigger PredictHQ event sync for the current tenant",
+)
+async def trigger_event_sync(
+    background_tasks: BackgroundTasks,
+    body: EventSyncRequest = EventSyncRequest(),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSyncResponse:
+    """
+    Enqueues a background PredictHQ event ingestion job for the authenticated
+    user's property.
+
+    Returns **202 Accepted** immediately; ingestion runs asynchronously.
+    Events within ``radius_km`` of the property GPS (default 5 km) and
+    starting within the next ``days_ahead`` days (default 30) are fetched.
+    """
+    result = await db.execute(
+        select(RestaurantProfile).where(
+            RestaurantProfile.owner_id == current_user["id"]
+            if not body.tenant_id
+            else RestaurantProfile.tenant_id == body.tenant_id
+        )
+    )
+    profile = result.scalars().first()
+
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No restaurant profile found for this user.",
+        )
+
+    if profile.latitude is None or profile.longitude is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Property '{profile.tenant_id}' has no GPS coordinates. "
+                "Set latitude and longitude before syncing events."
+            ),
+        )
+
+    background_tasks.add_task(
+        _background_sync,
+        profile.tenant_id,
+        body.radius_km,
+        body.days_ahead,
+    )
+
+    return EventSyncResponse(
+        message="Event sync triggered — running in background.",
+        tenant_id=profile.tenant_id,
+        latitude=profile.latitude,
+        longitude=profile.longitude,
+        radius_km=body.radius_km,
+        records_queued=0,  # Unknown until background task completes
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -151,6 +151,50 @@ class WeatherForecast(Base):
     )
 
 
+class LocalEvent(Base):
+    """
+    Localized event data ingested from PredictHQ.
+    Story 3.2: one row per (tenant_id, event_id).
+    Unique constraint on (tenant_id, event_id) enforces idempotent upserts.
+    """
+    __tablename__ = "local_events"
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(String, ForeignKey("restaurant_profiles.tenant_id"), index=True, nullable=False)
+
+    # PredictHQ event identifier (stable across re-syncs)
+    event_id = Column(String, nullable=False)
+
+    # Event metadata
+    title = Column(String, nullable=False)
+    category = Column(String, nullable=False)   # e.g. "conferences", "concerts", "sports"
+    rank = Column(Integer)                       # PredictHQ rank (0-100)
+    local_rank = Column(Integer)                 # Local rank within radius
+    phq_attendance = Column(Integer)             # Predicted attendance
+
+    # Temporal data
+    start_dt = Column(DateTime(timezone=True), nullable=False, index=True)
+    end_dt = Column(DateTime(timezone=True))
+
+    # Location (centroid of the event)
+    latitude = Column(Float)
+    longitude = Column(Float)
+
+    # Raw payload for auditing / future feature extraction
+    raw_labels = Column(JSON)
+
+    fetched_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    __table_args__ = (
+        # Idempotency: upsert on (tenant_id, event_id)
+        __import__("sqlalchemy").UniqueConstraint(
+            "tenant_id", "event_id",
+            name="uq_local_event",
+        ),
+    )
+
+
 class RecommendationCache(Base):
     """
     Persistence for AI staffing recommendations.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,10 +10,11 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.error_handlers import problem_details_handler
-from app.api.routes import pms, webhooks, auth, dashboard, predictions, reports, weather, baselines
+from app.api.routes import pms, webhooks, auth, dashboard, predictions, reports, weather, baselines, events
 from app.db.models import Base
 from app.db.session import engine
 from app.workers.weather_sync import start_weather_scheduler, stop_weather_scheduler
+from app.workers.event_sync import start_event_scheduler, stop_event_scheduler
 
 app = FastAPI(
     title="Aetherix API",
@@ -34,11 +35,13 @@ async def on_startup():
         # Create tables
         await conn.run_sync(Base.metadata.create_all)
     start_weather_scheduler()
+    start_event_scheduler()
 
 
 @app.on_event("shutdown")
 async def on_shutdown():
     stop_weather_scheduler()
+    stop_event_scheduler()
 
 # Include routers
 app.include_router(pms.router, prefix="/api/v1")
@@ -49,6 +52,7 @@ app.include_router(dashboard.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
 app.include_router(weather.router, prefix="/api/v1")
 app.include_router(baselines.router, prefix="/api/v1")
+app.include_router(events.router, prefix="/api/v1")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas/events.py
+++ b/backend/app/schemas/events.py
@@ -1,0 +1,83 @@
+"""Pydantic schemas for PredictHQ event ingestion (HOS-84 Story 3.2).
+
+All output models use camelCase aliases per architecture constraint.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+def _to_camel(s: str) -> str:
+    parts = s.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+class _CamelModel(BaseModel):
+    model_config = {"populate_by_name": True, "alias_generator": _to_camel}
+
+
+# ---------------------------------------------------------------------------
+# Inbound (normalized from PredictHQ API response)
+# ---------------------------------------------------------------------------
+
+class EventRecord(_CamelModel):
+    """One event ingested from PredictHQ /v2/events."""
+
+    event_id: str = Field(..., description="Stable PredictHQ event UUID")
+    title: str = Field(..., description="Event title")
+    category: str = Field(..., description="PredictHQ category slug (e.g. 'conferences')")
+    rank: Optional[int] = Field(None, ge=0, le=100, description="PredictHQ rank score")
+    local_rank: Optional[int] = Field(None, ge=0, le=100, description="Local rank within radius")
+    phq_attendance: Optional[int] = Field(None, description="Predicted attendance")
+    start_dt: datetime = Field(..., description="Event start (UTC)")
+    end_dt: Optional[datetime] = Field(None, description="Event end (UTC)")
+    latitude: Optional[float] = Field(None, description="Event centroid latitude")
+    longitude: Optional[float] = Field(None, description="Event centroid longitude")
+    raw_labels: Optional[List[str]] = Field(None, description="PredictHQ label tags")
+
+
+# ---------------------------------------------------------------------------
+# API request / response
+# ---------------------------------------------------------------------------
+
+class EventSyncRequest(_CamelModel):
+    """Body for POST /api/v1/events/sync (all fields optional)."""
+
+    tenant_id: Optional[str] = None
+    radius_km: float = Field(5.0, gt=0, le=50, description="Search radius in km (default 5 km)")
+    days_ahead: int = Field(30, gt=0, le=90, description="Number of days ahead to fetch (default 30)")
+
+
+class EventSyncResponse(_CamelModel):
+    """202 Accepted response for POST /api/v1/events/sync."""
+
+    message: str
+    tenant_id: str
+    latitude: float
+    longitude: float
+    radius_km: float
+    records_queued: int = Field(..., description="Number of events scheduled for upsert")
+
+
+class LocalEventOut(_CamelModel):
+    """Serialized LocalEvent ORM row returned by read endpoints."""
+
+    id: int
+    tenant_id: str
+    event_id: str
+    title: str
+    category: str
+    rank: Optional[int]
+    local_rank: Optional[int]
+    phq_attendance: Optional[int]
+    start_dt: datetime
+    end_dt: Optional[datetime]
+    latitude: Optional[float]
+    longitude: Optional[float]
+    raw_labels: Optional[List[str]]
+    fetched_at: Optional[datetime]
+
+    model_config = {"from_attributes": True, "populate_by_name": True, "alias_generator": _to_camel}

--- a/backend/app/services/event_ingestion.py
+++ b/backend/app/services/event_ingestion.py
@@ -1,0 +1,291 @@
+"""EventIngestionService — HOS-84 Story 3.2.
+
+Fetches upcoming local events from PredictHQ (within a configurable radius
+around the property's GPS coordinates) and upserts normalized records into
+the ``local_events`` table.
+
+Design constraints followed:
+- Fat Backend: no PredictHQ API calls from Next.js (architecture constraint).
+- Tenacity retry: max 3 attempts, exponential back-off (SC #6).
+- Idempotency: ON CONFLICT DO NOTHING on (tenant_id, event_id) (SC #7).
+- Tenant isolation: every row carries tenant_id; RLS enforced at DB level (SC #5).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Optional
+
+import httpx
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+    before_sleep_log,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import LocalEvent, RestaurantProfile
+from app.schemas.events import EventRecord
+
+logger = logging.getLogger(__name__)
+
+# PredictHQ API base URL
+_PHQ_BASE_URL = "https://api.predicthq.com/v1"
+
+# Default search window and radius
+_DEFAULT_RADIUS_KM = 5
+_DEFAULT_DAYS_AHEAD = 30
+
+# Categories relevant to F&B demand prediction
+_DEFAULT_CATEGORIES = (
+    "conferences,concerts,festivals,performing-arts,sports,"
+    "expos,community,public-holidays"
+)
+
+
+class EventIngestionService:
+    """Orchestrates fetching + normalizing + persisting PredictHQ event data."""
+
+    def __init__(self, http_client: Optional[httpx.AsyncClient] = None) -> None:
+        # Allow injection for testing
+        self._client = http_client
+        self._api_key: str = os.environ.get("PREDICTHQ_API_KEY", "")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def sync_for_tenant(
+        self,
+        session: AsyncSession,
+        profile: RestaurantProfile,
+        radius_km: float = _DEFAULT_RADIUS_KM,
+        days_ahead: int = _DEFAULT_DAYS_AHEAD,
+    ) -> int:
+        """Fetch and persist upcoming events for one property.
+
+        Returns the number of rows upserted (new records only; duplicates
+        are silently ignored).
+
+        Raises ``ValueError`` if the property has no GPS coordinates.
+        Raises ``RuntimeError`` if PREDICTHQ_API_KEY is not configured.
+        """
+        if profile.latitude is None or profile.longitude is None:
+            raise ValueError(
+                f"Property '{profile.tenant_id}' has no GPS coordinates — "
+                "set latitude/longitude before syncing events."
+            )
+
+        if not self._api_key:
+            raise RuntimeError(
+                "PREDICTHQ_API_KEY is not set. "
+                "Configure it in the environment before running event sync."
+            )
+
+        raw_events = await self._fetch_events(
+            lat=profile.latitude,
+            lng=profile.longitude,
+            radius_km=radius_km,
+            days_ahead=days_ahead,
+        )
+        records = self._normalize(raw_events)
+        inserted = await self._upsert(session, profile.tenant_id, records)
+        logger.info(
+            "Event sync OK  tenant=%s  rows_new=%d  rows_total=%d",
+            profile.tenant_id,
+            inserted,
+            len(records),
+        )
+        return inserted
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @retry(
+        retry=retry_if_exception_type((httpx.HTTPError, httpx.TimeoutException)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    async def _fetch_events(
+        self,
+        lat: float,
+        lng: float,
+        radius_km: float,
+        days_ahead: int,
+    ) -> List[dict]:
+        """GET PredictHQ /v1/events with tenacity retry (SC #6).
+
+        Handles pagination automatically and returns a flat list of raw
+        event dicts across all pages.
+        """
+        today = date.today()
+        date_from = today.isoformat()
+        date_to = (today + timedelta(days=days_ahead)).isoformat()
+
+        params = {
+            "within": f"{radius_km}km@{lat},{lng}",
+            "active.gte": date_from,
+            "active.lte": date_to,
+            "category": _DEFAULT_CATEGORIES,
+            "limit": 100,
+            "sort": "rank",
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Accept": "application/json",
+        }
+
+        all_results: List[dict] = []
+        url = f"{_PHQ_BASE_URL}/events/"
+
+        while url:
+            if self._client is not None:
+                resp = await self._client.get(url, params=params, headers=headers, timeout=15)
+            else:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(url, params=params, headers=headers, timeout=15)
+
+            resp.raise_for_status()
+            data = resp.json()
+
+            all_results.extend(data.get("results", []))
+
+            # Follow cursor-based pagination (PredictHQ uses `next` URL)
+            next_url = data.get("next")
+            if next_url:
+                url = next_url
+                params = {}  # next URL already encodes all params
+            else:
+                break
+
+        logger.debug("PredictHQ returned %d raw events", len(all_results))
+        return all_results
+
+    @staticmethod
+    def _normalize(raw_events: List[dict]) -> List[EventRecord]:
+        """Map PredictHQ event dicts → list of EventRecord."""
+        records: List[EventRecord] = []
+
+        for ev in raw_events:
+            # Parse start / end datetimes (PredictHQ uses ISO-8601)
+            start_dt = _parse_phq_datetime(ev.get("start"))
+            if start_dt is None:
+                logger.warning("Skipping event with unparseable start: %s", ev.get("id"))
+                continue
+
+            end_dt = _parse_phq_datetime(ev.get("end"))
+
+            # Extract centroid from geo.geometry.coordinates [lng, lat]
+            lat: Optional[float] = None
+            lng: Optional[float] = None
+            geo = ev.get("geo") or {}
+            geometry = geo.get("geometry") or {}
+            coords = geometry.get("coordinates")
+            if coords and len(coords) >= 2:
+                lng, lat = coords[0], coords[1]
+
+            records.append(
+                EventRecord(
+                    event_id=ev.get("id", ""),
+                    title=ev.get("title", ""),
+                    category=ev.get("category", "other"),
+                    rank=ev.get("rank"),
+                    local_rank=ev.get("local_rank"),
+                    phq_attendance=ev.get("phq_attendance"),
+                    start_dt=start_dt,
+                    end_dt=end_dt,
+                    latitude=lat,
+                    longitude=lng,
+                    raw_labels=ev.get("labels"),
+                )
+            )
+
+        return records
+
+    @staticmethod
+    async def _upsert(
+        session: AsyncSession,
+        tenant_id: str,
+        records: List[EventRecord],
+    ) -> int:
+        """Bulk-insert records; skip duplicates via ON CONFLICT DO NOTHING (SC #7).
+
+        Uses the PostgreSQL dialect for production (Supabase) and falls back to
+        the SQLite dialect when running tests against an in-memory database.
+
+        Returns the count of newly inserted rows.
+        """
+        if not records:
+            return 0
+
+        now = datetime.now(tz=timezone.utc)
+        values = [
+            {
+                "tenant_id": tenant_id,
+                "event_id": r.event_id,
+                "title": r.title,
+                "category": r.category,
+                "rank": r.rank,
+                "local_rank": r.local_rank,
+                "phq_attendance": r.phq_attendance,
+                "start_dt": r.start_dt,
+                "end_dt": r.end_dt,
+                "latitude": r.latitude,
+                "longitude": r.longitude,
+                "raw_labels": r.raw_labels,
+                "fetched_at": now,
+                "created_at": now,
+            }
+            for r in records
+        ]
+
+        # Resolve dialect at runtime so the same service code works in tests
+        # (SQLite) and production (PostgreSQL / Supabase).
+        dialect_name: str = session.get_bind().dialect.name  # type: ignore[union-attr]
+
+        if dialect_name == "sqlite":
+            from sqlalchemy.dialects.sqlite import insert as _insert
+
+            stmt = (
+                _insert(LocalEvent)
+                .values(values)
+                .on_conflict_do_nothing()
+            )
+        else:
+            # PostgreSQL (default / production)
+            from sqlalchemy.dialects.postgresql import insert as _insert  # type: ignore[no-redef]
+
+            stmt = (
+                _insert(LocalEvent)
+                .values(values)
+                .on_conflict_do_nothing(
+                    index_elements=["tenant_id", "event_id"]
+                )
+            )
+
+        result = await session.execute(stmt)
+        await session.commit()
+        return result.rowcount if result.rowcount is not None else 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_phq_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse a PredictHQ ISO-8601 datetime string → UTC-aware datetime."""
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, AttributeError):
+        return None

--- a/backend/app/workers/event_sync.py
+++ b/backend/app/workers/event_sync.py
@@ -1,0 +1,79 @@
+"""APScheduler background worker — PredictHQ event sync daily at 06:00 UTC (HOS-84 Story 3.2).
+
+The scheduler is started on FastAPI startup and stopped on shutdown.
+Each job iteration:
+  1. Fetches all RestaurantProfile rows that have GPS coordinates.
+  2. Calls EventIngestionService.sync_for_tenant for each profile.
+  3. Logs per-tenant success / failure; a per-tenant failure does NOT
+     abort the remaining tenants (SC #6).
+"""
+from __future__ import annotations
+
+import logging
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from sqlalchemy.future import select
+
+from app.db.session import AsyncSessionLocal
+from app.db.models import RestaurantProfile
+from app.services.event_ingestion import EventIngestionService
+
+logger = logging.getLogger(__name__)
+
+_scheduler = AsyncIOScheduler()
+
+
+async def _run_event_sync_for_all_tenants() -> None:
+    """Iterate every property with GPS coords and sync PredictHQ events."""
+    service = EventIngestionService()
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(RestaurantProfile).where(
+                RestaurantProfile.latitude.isnot(None),
+                RestaurantProfile.longitude.isnot(None),
+            )
+        )
+        profiles = result.scalars().all()
+
+    logger.info("Event sync job started — %d properties with GPS", len(profiles))
+
+    for profile in profiles:
+        try:
+            async with AsyncSessionLocal() as session:
+                rows = await service.sync_for_tenant(session, profile)
+            logger.info(
+                "Event sync OK  tenant=%s  new_rows=%d",
+                profile.tenant_id,
+                rows,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Per-tenant failure must NOT affect other tenants (SC #6)
+            logger.error(
+                "Event sync FAILED  tenant=%s  error=%s",
+                profile.tenant_id,
+                exc,
+                exc_info=True,
+            )
+
+
+def start_event_scheduler() -> None:
+    """Register the daily 06:00 UTC event sync job and start the scheduler."""
+    _scheduler.add_job(
+        _run_event_sync_for_all_tenants,
+        trigger=CronTrigger(hour=6, minute=0, timezone="UTC"),
+        id="event_sync_daily_06utc",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    _scheduler.start()
+    logger.info("Event scheduler started (cron=daily 06:00 UTC)")
+
+
+def stop_event_scheduler() -> None:
+    """Gracefully shut down the scheduler on app shutdown."""
+    if _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("Event scheduler stopped")

--- a/backend/tests/test_event_ingestion.py
+++ b/backend/tests/test_event_ingestion.py
@@ -1,0 +1,413 @@
+"""Tests for EventIngestionService — HOS-84 Story 3.2.
+
+Coverage:
+  Unit:
+    - _normalize(): maps PredictHQ response correctly
+    - _normalize(): skips events with unparseable start datetime
+    - _normalize(): extracts geo coordinates from GeoJSON
+    - _parse_phq_datetime(): handles Z-suffix, naive, and None values
+  Integration (mocked HTTP + in-memory SQLite):
+    - sync_for_tenant(): raises ValueError when GPS missing
+    - sync_for_tenant(): raises RuntimeError when API key not set
+    - sync_for_tenant(): calls PredictHQ and persists records
+    - Idempotency: re-running sync does NOT create duplicate rows
+    - Cross-tenant isolation: tenant A cannot see tenant B rows
+    - API failure retries and re-raises after exhaustion
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.future import select
+
+from app.db.models import Base, LocalEvent, RestaurantProfile
+from app.schemas.events import EventRecord
+from app.services.event_ingestion import EventIngestionService, _parse_phq_datetime
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def async_session():
+    """In-memory async SQLite session for integration tests."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def _make_profile(
+    tenant_id: str,
+    lat: float | None = 48.8566,
+    lng: float | None = 2.3522,
+) -> RestaurantProfile:
+    return RestaurantProfile(
+        id=tenant_id,
+        tenant_id=tenant_id,
+        property_name="Test Hotel",
+        outlet_name="Test Restaurant",
+        total_seats=100,
+        latitude=lat,
+        longitude=lng,
+    )
+
+
+def _phq_event(
+    event_id: str = "evt-001",
+    title: str = "Tech Conference 2026",
+    category: str = "conferences",
+    start: str = "2026-03-25T09:00:00Z",
+    end: str = "2026-03-25T18:00:00Z",
+    rank: int = 72,
+    local_rank: int = 55,
+    phq_attendance: int = 3000,
+    lat: float = 48.860,
+    lng: float = 2.350,
+    labels: List[str] | None = None,
+) -> Dict[str, Any]:
+    return {
+        "id": event_id,
+        "title": title,
+        "category": category,
+        "rank": rank,
+        "local_rank": local_rank,
+        "phq_attendance": phq_attendance,
+        "start": start,
+        "end": end,
+        "geo": {
+            "geometry": {
+                "type": "Point",
+                "coordinates": [lng, lat],
+            }
+        },
+        "labels": labels or ["technology", "b2b"],
+    }
+
+
+def _phq_page(events: List[Dict], next_url: str | None = None) -> Dict[str, Any]:
+    """Minimal PredictHQ paginated response."""
+    return {
+        "count": len(events),
+        "next": next_url,
+        "previous": None,
+        "results": events,
+    }
+
+
+def _mock_http_client(pages: List[Dict]) -> AsyncMock:
+    """Build a mock AsyncClient that returns pages in sequence."""
+    responses = []
+    for page in pages:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = page
+        responses.append(mock_resp)
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(side_effect=responses)
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _parse_phq_datetime
+# ---------------------------------------------------------------------------
+
+class TestParsePHQDatetime:
+    def test_z_suffix(self):
+        dt = _parse_phq_datetime("2026-03-25T09:00:00Z")
+        assert dt is not None
+        assert dt.tzinfo is not None
+        assert dt.year == 2026
+
+    def test_offset_aware(self):
+        dt = _parse_phq_datetime("2026-03-25T09:00:00+02:00")
+        assert dt is not None
+        assert dt.tzinfo is not None
+
+    def test_naive_iso(self):
+        dt = _parse_phq_datetime("2026-03-25T09:00:00")
+        assert dt is not None
+        assert dt.tzinfo == timezone.utc
+
+    def test_none_input(self):
+        assert _parse_phq_datetime(None) is None
+
+    def test_empty_string(self):
+        assert _parse_phq_datetime("") is None
+
+    def test_garbage_string(self):
+        assert _parse_phq_datetime("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _normalize
+# ---------------------------------------------------------------------------
+
+class TestNormalize:
+    def test_maps_all_fields(self):
+        raw = [_phq_event()]
+        records = EventIngestionService._normalize(raw)
+
+        assert len(records) == 1
+        r = records[0]
+        assert r.event_id == "evt-001"
+        assert r.title == "Tech Conference 2026"
+        assert r.category == "conferences"
+        assert r.rank == 72
+        assert r.local_rank == 55
+        assert r.phq_attendance == 3000
+        assert r.start_dt.tzinfo is not None
+        assert r.end_dt is not None
+        assert r.latitude == pytest.approx(48.860)
+        assert r.longitude == pytest.approx(2.350)
+        assert r.raw_labels == ["technology", "b2b"]
+
+    def test_skips_event_with_no_start(self, caplog):
+        import logging
+        raw = [
+            {**_phq_event(event_id="bad"), "start": None},
+            _phq_event(event_id="good"),
+        ]
+        with caplog.at_level(logging.WARNING):
+            records = EventIngestionService._normalize(raw)
+
+        assert len(records) == 1
+        assert records[0].event_id == "good"
+
+    def test_skips_event_with_unparseable_start(self):
+        raw = [
+            {**_phq_event(event_id="bad"), "start": "not-a-date"},
+            _phq_event(event_id="ok"),
+        ]
+        records = EventIngestionService._normalize(raw)
+        assert len(records) == 1
+        assert records[0].event_id == "ok"
+
+    def test_extracts_geo_from_geojson(self):
+        raw = [_phq_event(lat=51.507, lng=-0.127)]
+        records = EventIngestionService._normalize(raw)
+        assert records[0].latitude == pytest.approx(51.507)
+        assert records[0].longitude == pytest.approx(-0.127)
+
+    def test_geo_missing_gracefully(self):
+        ev = _phq_event()
+        del ev["geo"]
+        records = EventIngestionService._normalize([ev])
+        assert records[0].latitude is None
+        assert records[0].longitude is None
+
+    def test_optional_fields_none(self):
+        ev = _phq_event()
+        ev["rank"] = None
+        ev["local_rank"] = None
+        ev["phq_attendance"] = None
+        ev["end"] = None
+        ev["labels"] = None
+        records = EventIngestionService._normalize([ev])
+        r = records[0]
+        assert r.rank is None
+        assert r.end_dt is None
+        assert r.raw_labels is None
+
+    def test_empty_list(self):
+        assert EventIngestionService._normalize([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — sync_for_tenant (mocked HTTP + SQLite)
+# ---------------------------------------------------------------------------
+
+class TestSyncForTenant:
+    @pytest.mark.asyncio
+    async def test_raises_when_no_gps(self, async_session):
+        profile = _make_profile("tenant_no_gps", lat=None, lng=None)
+        async_session.add(profile)
+        await async_session.commit()
+
+        service = EventIngestionService()
+        with pytest.raises(ValueError, match="GPS coordinates"):
+            await service.sync_for_tenant(async_session, profile)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_api_key(self, async_session):
+        profile = _make_profile("tenant_no_key")
+        async_session.add(profile)
+        await async_session.commit()
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": ""}):
+            service = EventIngestionService()
+            with pytest.raises(RuntimeError, match="PREDICTHQ_API_KEY"):
+                await service.sync_for_tenant(async_session, profile)
+
+    @pytest.mark.asyncio
+    async def test_persists_records(self, async_session):
+        profile = _make_profile("tenant_paris")
+        async_session.add(profile)
+        await async_session.commit()
+
+        events = [_phq_event(event_id=f"evt-{i:03d}") for i in range(3)]
+        mock_client = _mock_http_client([_phq_page(events)])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            inserted = await service.sync_for_tenant(async_session, profile)
+
+        assert inserted == 3
+        mock_client.get.assert_awaited_once()
+
+        rows = (
+            await async_session.execute(
+                select(LocalEvent).where(LocalEvent.tenant_id == "tenant_paris")
+            )
+        ).scalars().all()
+        assert len(rows) == 3
+
+    @pytest.mark.asyncio
+    async def test_persists_all_fields(self, async_session):
+        profile = _make_profile("tenant_fields")
+        async_session.add(profile)
+        await async_session.commit()
+
+        ev = _phq_event(event_id="evt-check", title="Jazz Fest", category="concerts")
+        mock_client = _mock_http_client([_phq_page([ev])])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            await service.sync_for_tenant(async_session, profile)
+
+        row = (
+            await async_session.execute(
+                select(LocalEvent).where(LocalEvent.event_id == "evt-check")
+            )
+        ).scalars().first()
+
+        assert row is not None
+        assert row.title == "Jazz Fest"
+        assert row.category == "concerts"
+        assert row.rank == 72
+        assert row.phq_attendance == 3000
+        assert row.tenant_id == "tenant_fields"
+
+    @pytest.mark.asyncio
+    async def test_idempotency_no_duplicates(self, async_session):
+        """Running sync twice for the same property+events must not create duplicates."""
+        profile = _make_profile("tenant_idempotent")
+        async_session.add(profile)
+        await async_session.commit()
+
+        events = [_phq_event(event_id="evt-001"), _phq_event(event_id="evt-002")]
+        # Provide two identical pages so both calls succeed
+        mock_client = _mock_http_client([_phq_page(events), _phq_page(events)])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            first_run = await service.sync_for_tenant(async_session, profile)
+            second_run = await service.sync_for_tenant(async_session, profile)
+
+        assert first_run == 2
+        assert second_run == 0  # All conflict — no new rows
+
+        rows = (
+            await async_session.execute(
+                select(LocalEvent).where(LocalEvent.tenant_id == "tenant_idempotent")
+            )
+        ).scalars().all()
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_isolation(self, async_session):
+        """Rows inserted for tenant A must not be visible when querying tenant B."""
+        profile_a = _make_profile("tenant_a_ev")
+        profile_b = _make_profile("tenant_b_ev", lat=51.5074, lng=-0.1278)
+        async_session.add_all([profile_a, profile_b])
+        await async_session.commit()
+
+        events_a = [_phq_event(event_id="evt-a1"), _phq_event(event_id="evt-a2")]
+        mock_client = _mock_http_client([_phq_page(events_a)])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            await service.sync_for_tenant(async_session, profile_a)
+
+        rows_b = (
+            await async_session.execute(
+                select(LocalEvent).where(LocalEvent.tenant_id == "tenant_b_ev")
+            )
+        ).scalars().all()
+        assert rows_b == [], "Tenant B must not see Tenant A's event rows"
+
+    @pytest.mark.asyncio
+    async def test_http_failure_reraises_after_retries(self, async_session):
+        """After all retries exhausted, the HTTP exception propagates."""
+        profile = _make_profile("tenant_fail_ev")
+        async_session.add(profile)
+        await async_session.commit()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("unreachable"))
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            with pytest.raises(httpx.ConnectError):
+                await service.sync_for_tenant(async_session, profile)
+
+    @pytest.mark.asyncio
+    async def test_empty_response_inserts_zero(self, async_session):
+        """PredictHQ returning no events for a radius should not crash."""
+        profile = _make_profile("tenant_empty")
+        async_session.add(profile)
+        await async_session.commit()
+
+        mock_client = _mock_http_client([_phq_page([])])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            inserted = await service.sync_for_tenant(async_session, profile)
+
+        assert inserted == 0
+
+    @pytest.mark.asyncio
+    async def test_categories_cover_fb_relevant_types(self, async_session):
+        """Ensure ingested categories include F&B-relevant event types."""
+        profile = _make_profile("tenant_cats")
+        async_session.add(profile)
+        await async_session.commit()
+
+        categories_to_test = ["conferences", "concerts", "sports", "festivals"]
+        events = [
+            _phq_event(event_id=f"evt-{cat}", category=cat)
+            for cat in categories_to_test
+        ]
+        mock_client = _mock_http_client([_phq_page(events)])
+
+        with patch.dict(os.environ, {"PREDICTHQ_API_KEY": "test-key"}):
+            service = EventIngestionService(http_client=mock_client)
+            inserted = await service.sync_for_tenant(async_session, profile)
+
+        assert inserted == len(categories_to_test)
+
+        rows = (
+            await async_session.execute(
+                select(LocalEvent).where(LocalEvent.tenant_id == "tenant_cats")
+            )
+        ).scalars().all()
+        persisted_categories = {r.category for r in rows}
+        assert persisted_categories == set(categories_to_test)


### PR DESCRIPTION
Ingests localized event data (conferences, concerts, sports, etc.) within a configurable radius around each property's GPS coordinates so the Semantic Engine can identify external demand drivers.

Changes:
- db/models.py: add LocalEvent ORM model with unique constraint (tenant_id, event_id) for idempotent upserts and full tenant isolation via RLS-ready tenant_id FK
- schemas/events.py: EventRecord, EventSyncRequest, EventSyncResponse, LocalEventOut with camelCase alias generator (architecture constraint)
- services/event_ingestion.py: EventIngestionService with tenacity retry (3 attempts, exponential back-off), paginated PredictHQ /v1/events/ fetching, _normalize() for GeoJSON extraction, dialect-aware ON CONFLICT DO NOTHING upsert (SQLite + PG)
- workers/event_sync.py: APScheduler CronTrigger daily at 06:00 UTC iterating all profiles with GPS; per-tenant failure does not abort remaining tenants (SC #6)
- api/routes/events.py: POST /api/v1/events/sync — 202 Accepted with BackgroundTasks, JWT-authenticated, configurable radius_km and days_ahead
- main.py: register events router and start/stop event scheduler on lifecycle hooks
- tests/test_event_ingestion.py: 22 tests covering _parse_phq_datetime, _normalize (all fields, missing geo, skipped events), sync_for_tenant (no GPS, no API key, persistence, field mapping, idempotency, cross-tenant isolation, HTTP failure retry, empty response, category coverage)

All 52 tests pass (22 new + 30 existing).

https://claude.ai/code/session_0187mLcnyw7Uje6P2No65SZq