### PR TITLE
feat(3.3b): Calculate Financial ROI for Detected Anomalies (HOS-22)

### DIFF
--- a/backend/app/api/routes/anomalies.py
+++ b/backend/app/api/routes/anomalies.py
@@ -24,12 +24,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_current_user
 from app.db.session import get_db
-from app.schemas.anomalies import AnomalyListResponse, AnomalyScanResponse, DemandAnomalyRead
+from app.schemas.anomalies import (
+    AnomalyListResponse,
+    AnomalyScanResponse,
+    DemandAnomalyRead,
+    ROICalculationResponse,
+)
 from app.services.anomaly_detection import AnomalyDetectionService
+from app.services.roi_calculator import ROICalculatorService
 
 router = APIRouter(prefix="/anomalies", tags=["anomalies"])
 
 _service = AnomalyDetectionService()
+_roi_service = ROICalculatorService()
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +161,44 @@ async def list_anomalies(
         page=page,
         page_size=page_size,
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/anomalies/roi  (Story 3.3b)
+# ---------------------------------------------------------------------------
+@router.post(
+    "/roi",
+    status_code=202,
+    response_model=ROICalculationResponse,
+    summary="Trigger ROI calculation for all detected anomalies (manual trigger)",
+)
+async def trigger_roi_calculation(
+    background_tasks: BackgroundTasks,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ROICalculationResponse:
+    """Immediately queue a full ROI calculation pass as a BackgroundTask.
+
+    Returns 202 Accepted; the ROI calculation runs asynchronously.
+    The service iterates all anomalies with status='detected', computes ROI
+    metrics, and updates status to 'roi_positive' where net_roi > 0.
+
+    AC 10: Manual trigger endpoint.
+    """
+    background_tasks.add_task(_run_roi_background)
+
+    return ROICalculationResponse(
+        message="ROI calculation triggered",
+        triggered_by=current_user.get("email"),
+    )
+
+
+async def _run_roi_background() -> None:
+    """Background task: open a fresh DB session and run the full ROI scan."""
+    from app.db.session import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        await _roi_service.run_full_scan(session)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,24 @@
+"""Application-level configuration constants for Aetherix backend.
+
+Values here are the system defaults; individual properties can override
+avg_spend_per_cover and staff_hourly_rate via the properties table
+(added in migration 20260323100000_add_roi_config_to_properties.sql).
+
+[Source: story 3.3b AC 7]
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# ROI Calculator defaults  (Story 3.3b)
+# ---------------------------------------------------------------------------
+
+#: Default average revenue per cover (£) used when the property has no
+#: per-property override set.
+DEFAULT_AVG_SPEND_PER_COVER: float = 40.0
+
+#: Default hourly cost per additional front-of-house staff member (£).
+DEFAULT_STAFF_HOURLY_RATE: float = 14.0
+
+#: Default captation rate — fraction of the excess demand that the property
+#: is expected to capture when fully staffed.
+DEFAULT_CAPTATION_RATE: float = 0.7

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -60,7 +60,11 @@ class RestaurantProfile(Base):
     notification_channel = Column(String, default="whatsapp")
     phone_number = Column(String)
     email_address = Column(String)
-    
+
+    # ROI configuration (Story 3.3b) — overrides system defaults when set
+    avg_spend_per_cover = Column(Numeric(8, 2), nullable=True)   # £ per cover
+    staff_hourly_rate = Column(Numeric(8, 2), nullable=True)     # £ per staff/hour
+
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/app/schemas/anomalies.py
+++ b/backend/app/schemas/anomalies.py
@@ -84,3 +84,18 @@ class AnomalyListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class ROICalculationResponse(BaseModel):
+    """Response body for POST /api/v1/anomalies/roi (202 Accepted).
+
+    Story 3.3b — manual trigger for ROI calculation.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    message: str = "ROI calculation triggered"
+    triggered_by: Optional[str] = None

--- a/backend/app/services/roi_calculator.py
+++ b/backend/app/services/roi_calculator.py
@@ -1,0 +1,329 @@
+"""ROI Calculator Service.
+
+Implements Story 3.3b: Calculate Financial ROI for Detected Anomalies.
+
+Business logic:
+  revenue_opportunity = captation_rate × expected_additional_covers × avg_spend_per_cover
+  labor_cost          = recommended_headcount × hourly_rate × window_duration_hours
+  net_roi             = revenue_opportunity - labor_cost
+
+  If net_roi > 0  → anomaly status updated to 'roi_positive'
+  Otherwise       → anomaly status remains 'detected'
+
+For lulls (direction == 'lull'):
+  revenue_opp = 0, labor_cost = 0, net_roi = 0  (no staffing action required)
+
+Headcount scale (deviation_pct from baseline):
+  20 – 35 %  →  1 extra head
+  35 – 55 %  →  2 extra heads
+  55 – 80 %  →  3 extra heads
+  > 80 %     →  4 extra heads (max)
+  lull / ≤ 0 →  0
+
+Architecture constraints:
+- All business logic lives here (Fat Backend).
+- Routes and workers delegate to this service; no logic in route handlers.
+- Uses AsyncSession (sqlalchemy.ext.asyncio) throughout.
+- Idempotent: re-running updates existing ROI fields without creating
+  duplicates (AC 8).
+[Source: story 3.3b, architecture.md#Architectural-Boundaries]
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from decimal import Decimal
+from typing import Dict, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import (
+    DEFAULT_AVG_SPEND_PER_COVER,
+    DEFAULT_CAPTATION_RATE,
+    DEFAULT_STAFF_HOURLY_RATE,
+)
+
+logger = logging.getLogger(__name__)
+
+# Window duration used for labor cost calculation (hours)
+_WINDOW_HOURS: float = 4.0
+
+
+class ROICalculatorService:
+    """Financial ROI calculator for demand anomalies.
+
+    All public methods accept an AsyncSession.  The session is NOT committed
+    inside helpers; callers are responsible for committing or the top-level
+    ``run_for_property`` / ``run_full_scan`` methods handle it.
+    """
+
+    # ------------------------------------------------------------------
+    # Headcount Scale (AC: Headcount Scale table)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def recommended_headcount(deviation_pct: float) -> int:
+        """Map a deviation percentage to additional headcount required.
+
+        Args:
+            deviation_pct: Signed deviation from baseline (positive = surge,
+                           negative or zero = lull).
+
+        Returns:
+            Number of additional staff members required (0 for lulls).
+        """
+        if deviation_pct <= 0:
+            # Lull — no additional staffing action
+            return 0
+        if deviation_pct < 35:
+            return 1
+        if deviation_pct < 55:
+            return 2
+        if deviation_pct < 80:
+            return 3
+        return 4  # > 80 % — capped at 4
+
+    # ------------------------------------------------------------------
+    # Core calculation
+    # ------------------------------------------------------------------
+    def calculate_for_anomaly(
+        self,
+        *,
+        direction: str,
+        deviation_pct: float,
+        expected_demand: float,
+        baseline_demand: float,
+        avg_spend_per_cover: float,
+        staff_hourly_rate: float,
+        captation_rate: float = DEFAULT_CAPTATION_RATE,
+        window_hours: float = _WINDOW_HOURS,
+    ) -> Dict[str, float]:
+        """Calculate ROI metrics for a single anomaly.
+
+        Args:
+            direction:          'surge' or 'lull'.
+            deviation_pct:      (expected - baseline) / baseline * 100.
+            expected_demand:    Projected demand for the window.
+            baseline_demand:    Historical baseline demand for the window.
+            avg_spend_per_cover: Average revenue per cover (£).
+            staff_hourly_rate:  Hourly cost per additional staff member (£).
+            captation_rate:     Fraction of extra demand the property can capture.
+            window_hours:       Duration of the anomaly window in hours (default 4).
+
+        Returns:
+            dict with keys: revenue_opp, labor_cost, net_roi
+        """
+        if direction == "lull":
+            return {"revenue_opp": 0.0, "labor_cost": 0.0, "net_roi": 0.0}
+
+        # Surge: calculate additional covers above baseline
+        expected_additional_covers = max(0.0, expected_demand - baseline_demand)
+
+        revenue_opp = captation_rate * expected_additional_covers * avg_spend_per_cover
+
+        headcount = self.recommended_headcount(deviation_pct)
+        labor_cost = headcount * staff_hourly_rate * window_hours
+
+        net_roi = revenue_opp - labor_cost
+
+        return {
+            "revenue_opp": round(revenue_opp, 2),
+            "labor_cost": round(labor_cost, 2),
+            "net_roi": round(net_roi, 2),
+        }
+
+    # ------------------------------------------------------------------
+    # Property-level runner
+    # ------------------------------------------------------------------
+    async def run_for_property(
+        self,
+        db: AsyncSession,
+        property_id: uuid.UUID,
+    ) -> int:
+        """Calculate ROI for all 'detected' anomalies for a single property.
+
+        Fetches the property's rate overrides (or uses system defaults) then
+        iterates every anomaly with status='detected', computes ROI, writes
+        back roi_revenue_opp, roi_labor_cost, roi_net, and updates status to
+        'roi_positive' when net_roi > 0.
+
+        Args:
+            db:          Async SQLAlchemy session.
+            property_id: UUID of the property to process.
+
+        Returns:
+            Number of anomaly rows updated.
+        """
+        # 1. Resolve property rate config
+        avg_spend, hourly_rate = await self._get_property_rates(db, property_id)
+
+        # 2. Fetch detected anomalies for this property
+        result = await db.execute(
+            text(
+                """
+                SELECT id, direction, deviation_pct, expected_demand, baseline_demand
+                FROM demand_anomalies
+                WHERE property_id = :property_id
+                  AND status = 'detected'
+                ORDER BY window_start
+                """
+            ),
+            {"property_id": str(property_id)},
+        )
+        rows = result.fetchall()
+
+        if not rows:
+            logger.debug(
+                "roi_calculator: no 'detected' anomalies for property %s", property_id
+            )
+            return 0
+
+        updated = 0
+        for row in rows:
+            anomaly_id = row[0]
+            direction = row[1]
+            deviation_pct = float(row[2]) if row[2] is not None else 0.0
+            expected_demand = float(row[3]) if row[3] is not None else 0.0
+            baseline_demand = float(row[4]) if row[4] is not None else 0.0
+
+            metrics = self.calculate_for_anomaly(
+                direction=direction,
+                deviation_pct=deviation_pct,
+                expected_demand=expected_demand,
+                baseline_demand=baseline_demand,
+                avg_spend_per_cover=avg_spend,
+                staff_hourly_rate=hourly_rate,
+            )
+
+            new_status = (
+                "roi_positive" if metrics["net_roi"] > 0 else "detected"
+            )
+
+            await db.execute(
+                text(
+                    """
+                    UPDATE demand_anomalies
+                    SET roi_revenue_opp = :revenue_opp,
+                        roi_labor_cost  = :labor_cost,
+                        roi_net         = :net_roi,
+                        status          = :status
+                    WHERE id = :id
+                    """
+                ),
+                {
+                    "revenue_opp": metrics["revenue_opp"],
+                    "labor_cost": metrics["labor_cost"],
+                    "net_roi": metrics["net_roi"],
+                    "status": new_status,
+                    "id": str(anomaly_id),
+                },
+            )
+            updated += 1
+
+        await db.commit()
+        logger.info(
+            "roi_calculator: updated %d anomalies for property %s",
+            updated,
+            property_id,
+        )
+        return updated
+
+    # ------------------------------------------------------------------
+    # Full cross-tenant scan
+    # ------------------------------------------------------------------
+    async def run_full_scan(self, db: AsyncSession) -> None:
+        """Run ROI calculation for all active properties in parallel.
+
+        Uses asyncio.gather to match the parallelism pattern of the anomaly
+        detection service (NFR5).
+
+        Args:
+            db: Async SQLAlchemy session.
+        """
+        try:
+            result = await db.execute(
+                text("SELECT id FROM properties WHERE is_active = TRUE")
+            )
+            property_ids = [row[0] for row in result.fetchall()]
+        except Exception:
+            logger.exception(
+                "roi_calculator: failed to fetch active properties"
+            )
+            return
+
+        if not property_ids:
+            logger.info("roi_calculator: no active properties, skipping")
+            return
+
+        tasks = [
+            self.run_for_property(db, property_id=pid)
+            for pid in property_ids
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        error_count = sum(1 for r in results if isinstance(r, Exception))
+        if error_count:
+            logger.warning(
+                "roi_calculator: %d/%d property runs raised exceptions",
+                error_count,
+                len(tasks),
+            )
+        for exc in results:
+            if isinstance(exc, Exception):
+                logger.error("roi_calculator property error: %s", exc)
+
+        total_updated = sum(r for r in results if isinstance(r, int))
+        logger.info(
+            "roi_calculator: full scan complete — %d anomalies updated across "
+            "%d properties",
+            total_updated,
+            len(property_ids),
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    async def _get_property_rates(
+        self,
+        db: AsyncSession,
+        property_id: uuid.UUID,
+    ) -> tuple[float, float]:
+        """Return (avg_spend_per_cover, staff_hourly_rate) for a property.
+
+        Falls back to system defaults (from config.py) when the columns are
+        NULL or when the properties table cannot be queried.
+        """
+        try:
+            result = await db.execute(
+                text(
+                    """
+                    SELECT avg_spend_per_cover, staff_hourly_rate
+                    FROM properties
+                    WHERE id = :property_id
+                    LIMIT 1
+                    """
+                ),
+                {"property_id": str(property_id)},
+            )
+            row = result.fetchone()
+            if row:
+                avg_spend = (
+                    float(row[0])
+                    if row[0] is not None
+                    else DEFAULT_AVG_SPEND_PER_COVER
+                )
+                hourly_rate = (
+                    float(row[1])
+                    if row[1] is not None
+                    else DEFAULT_STAFF_HOURLY_RATE
+                )
+                return avg_spend, hourly_rate
+        except Exception:
+            logger.debug(
+                "roi_calculator: properties rate lookup failed for %s — "
+                "using defaults",
+                property_id,
+            )
+
+        return DEFAULT_AVG_SPEND_PER_COVER, DEFAULT_STAFF_HOURLY_RATE

--- a/backend/app/workers/anomaly_scan.py
+++ b/backend/app/workers/anomaly_scan.py
@@ -1,12 +1,15 @@
 """APScheduler background worker for anomaly detection.
 
-Runs AnomalyDetectionService.run_full_scan() every 4 hours (cron: 0 */4 * * *).
+Runs AnomalyDetectionService.run_full_scan() every 4 hours (cron: 0 */4 * * *),
+then immediately chains ROI calculation (Story 3.3b AC 9).
+
 Registered on FastAPI startup in main.py alongside weather/event sync jobs.
 
 Architecture constraints:
 - Cron job is registered on startup; no state is kept in this module.
 - Session is opened per job execution and closed cleanly on exit.
-[Source: story 3.3a Task 4, architecture.md#Infrastructure-Deployment]
+- ROI calculation is chained within the same job execution (AC 9).
+[Source: story 3.3a Task 4, story 3.3b AC 9, architecture.md#Infrastructure-Deployment]
 """
 from __future__ import annotations
 
@@ -16,18 +19,30 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from app.db.session import AsyncSessionLocal
 from app.services.anomaly_detection import AnomalyDetectionService
+from app.services.roi_calculator import ROICalculatorService
 
 logger = logging.getLogger(__name__)
 
 _service = AnomalyDetectionService()
+_roi_service = ROICalculatorService()
 
 
 async def _run_anomaly_scan_job() -> None:
-    """Entry point called by APScheduler every 4 hours."""
+    """Entry point called by APScheduler every 4 hours.
+
+    Phase 1 — Anomaly detection scan.
+    Phase 2 — ROI calculation chain (AC 9: auto-chain after each scan cycle).
+    """
     logger.info("anomaly_scan: starting scheduled run")
     async with AsyncSessionLocal() as db:
         await _service.run_full_scan(db)
     logger.info("anomaly_scan: scheduled run complete")
+
+    # AC 9: chain ROI calculation immediately after the scan
+    logger.info("roi_calculator: starting post-scan ROI chain")
+    async with AsyncSessionLocal() as db:
+        await _roi_service.run_full_scan(db)
+    logger.info("roi_calculator: post-scan ROI chain complete")
 
 
 def register_anomaly_scan_job(scheduler: AsyncIOScheduler) -> None:

--- a/backend/tests/test_roi_calculator.py
+++ b/backend/tests/test_roi_calculator.py
@@ -1,0 +1,495 @@
+"""Tests for Story 3.3b: Calculate Financial ROI for Detected Anomalies.
+
+Covers all acceptance criteria:
+  AC 2  — revenue_opportunity = captation_rate × additional_covers × avg_spend
+  AC 3  — labor_cost = headcount × hourly_rate × window_hours
+  AC 4  — net_roi = revenue_opportunity - labor_cost
+  AC 5  — roi_positive flag sets status
+  AC 6  — ROI fields written back to anomaly row
+  AC 7  — configurable rates from config.py defaults
+  AC 8  — idempotency: re-run updates fields without duplicates
+  AC 9  — auto-chain in worker (smoke test)
+  AC 10 — POST /api/v1/anomalies/roi returns 202
+
+Test categories:
+  1. Unit — recommended_headcount() scale
+  2. Unit — calculate_for_anomaly() revenue / labor / net-roi
+  3. Unit — lull handling (all zeros)
+  4. Unit — status promotion: roi_positive vs remains detected
+  5. Integration — run_for_property() with mocked DB
+  6. Integration — idempotency (re-run)
+  7. Integration — POST /roi route returns 202
+  8. Unit — auto-chain smoke test (worker imports roi_calculator)
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.config import (
+    DEFAULT_AVG_SPEND_PER_COVER,
+    DEFAULT_CAPTATION_RATE,
+    DEFAULT_STAFF_HOURLY_RATE,
+)
+from app.core.error_handlers import problem_details_handler
+from app.services.roi_calculator import ROICalculatorService
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+@pytest.fixture
+def svc() -> ROICalculatorService:
+    return ROICalculatorService()
+
+
+# ===========================================================================
+# 1. Unit — recommended_headcount() scale
+# ===========================================================================
+
+class TestHeadownScale:
+    """AC: Headcount scale table."""
+
+    def test_headcount_scale_lull(self, svc: ROICalculatorService):
+        """Lull (deviation ≤ 0) → 0 extra heads."""
+        assert svc.recommended_headcount(-5.0) == 0
+        assert svc.recommended_headcount(0.0) == 0
+
+    def test_headcount_scale_low_surge(self, svc: ROICalculatorService):
+        """20–35 % surge → 1 extra head."""
+        assert svc.recommended_headcount(20.0) == 1
+        assert svc.recommended_headcount(25.0) == 1
+        assert svc.recommended_headcount(34.9) == 1
+
+    def test_headcount_scale_medium_surge(self, svc: ROICalculatorService):
+        """35–55 % surge → 2 extra heads."""
+        assert svc.recommended_headcount(35.0) == 2
+        assert svc.recommended_headcount(45.0) == 2
+        assert svc.recommended_headcount(54.9) == 2
+
+    def test_headcount_scale_high_surge(self, svc: ROICalculatorService):
+        """55–80 % surge → 3 extra heads."""
+        assert svc.recommended_headcount(55.0) == 3
+        assert svc.recommended_headcount(70.0) == 3
+        assert svc.recommended_headcount(79.9) == 3
+
+    def test_headcount_scale_max_surge(self, svc: ROICalculatorService):
+        """> 80 % surge → 4 extra heads (cap)."""
+        assert svc.recommended_headcount(80.0) == 4
+        assert svc.recommended_headcount(120.0) == 4
+        assert svc.recommended_headcount(500.0) == 4
+
+
+# ===========================================================================
+# 2. Unit — calculate_for_anomaly() revenue opportunity
+# ===========================================================================
+
+class TestRevenueOpportunityCalculation:
+    """AC 2: revenue_opportunity = captation_rate × additional_covers × avg_spend."""
+
+    def test_revenue_opportunity_basic_surge(self, svc: ROICalculatorService):
+        """Simple surge: 100 extra covers × 0.7 captation × £40 = £2800."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,
+            expected_demand=1100.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+            captation_rate=0.7,
+        )
+        assert result["revenue_opp"] == pytest.approx(2800.0, abs=0.01)
+
+    def test_revenue_opportunity_uses_default_captation_rate(
+        self, svc: ROICalculatorService
+    ):
+        """Default captation rate (0.7) is applied when not specified."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,
+            expected_demand=1100.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=DEFAULT_AVG_SPEND_PER_COVER,
+            staff_hourly_rate=DEFAULT_STAFF_HOURLY_RATE,
+        )
+        expected_rev = DEFAULT_CAPTATION_RATE * 100.0 * DEFAULT_AVG_SPEND_PER_COVER
+        assert result["revenue_opp"] == pytest.approx(expected_rev, abs=0.01)
+
+    def test_revenue_opportunity_zero_additional_covers(self, svc: ROICalculatorService):
+        """When expected_demand == baseline_demand, revenue_opp = 0."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,
+            expected_demand=1000.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["revenue_opp"] == 0.0
+
+
+# ===========================================================================
+# 3. Unit — labor cost calculation
+# ===========================================================================
+
+class TestLaborCostCalculation:
+    """AC 3: labor_cost = recommended_headcount × hourly_rate × window_hours."""
+
+    def test_labor_cost_1_head_4_hours(self, svc: ROICalculatorService):
+        """25 % surge → 1 head × £14/h × 4h = £56."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,
+            expected_demand=1250.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["labor_cost"] == pytest.approx(1 * 14.0 * 4.0, abs=0.01)
+
+    def test_labor_cost_4_heads_high_surge(self, svc: ROICalculatorService):
+        """100 % surge → 4 heads × £14/h × 4h = £224."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=100.0,
+            expected_demand=2000.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["labor_cost"] == pytest.approx(4 * 14.0 * 4.0, abs=0.01)
+
+    def test_labor_cost_custom_hourly_rate(self, svc: ROICalculatorService):
+        """Custom hourly rate is applied correctly."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=40.0,   # → 2 heads
+            expected_demand=1400.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=20.0,
+        )
+        assert result["labor_cost"] == pytest.approx(2 * 20.0 * 4.0, abs=0.01)
+
+
+# ===========================================================================
+# 4. Unit — lull handling (all zeros)
+# ===========================================================================
+
+class TestLullHandling:
+    """For lulls: revenue_opp = 0, labor_cost = 0, net_roi = 0."""
+
+    def test_lull_all_zeros(self, svc: ROICalculatorService):
+        result = svc.calculate_for_anomaly(
+            direction="lull",
+            deviation_pct=-30.0,
+            expected_demand=700.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["revenue_opp"] == 0.0
+        assert result["labor_cost"] == 0.0
+        assert result["net_roi"] == 0.0
+
+
+# ===========================================================================
+# 5. Unit — net_roi and status promotion
+# ===========================================================================
+
+class TestNetROIStatus:
+    """AC 4 & 5: net_roi calculation and status flag."""
+
+    def test_net_roi_positive_sets_roi_positive(self, svc: ROICalculatorService):
+        """When net_roi > 0 the caller (run_for_property) sets status='roi_positive'."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,       # 1 head → £56 labor
+            expected_demand=1100.0,   # 100 extra covers → £2800 revenue
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["net_roi"] > 0, "Expected positive net ROI"
+        assert result["net_roi"] == pytest.approx(
+            result["revenue_opp"] - result["labor_cost"], abs=0.01
+        )
+
+    def test_net_roi_zero_or_negative_keeps_detected(
+        self, svc: ROICalculatorService
+    ):
+        """Very small surge with high labor cost → net_roi <= 0."""
+        # Only 1 extra cover at £40, captured at 70 % → £28 revenue
+        # 1 head × £14 × 4h = £56 labor → net = -28
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=25.0,
+            expected_demand=1001.0,   # 1 extra cover
+            baseline_demand=1000.0,
+            avg_spend_per_cover=40.0,
+            staff_hourly_rate=14.0,
+        )
+        assert result["net_roi"] < 0, "Expected negative net ROI"
+
+    def test_net_roi_equals_revenue_minus_labor(self, svc: ROICalculatorService):
+        """net_roi == revenue_opp - labor_cost (AC 4 formula)."""
+        result = svc.calculate_for_anomaly(
+            direction="surge",
+            deviation_pct=60.0,
+            expected_demand=1600.0,
+            baseline_demand=1000.0,
+            avg_spend_per_cover=50.0,
+            staff_hourly_rate=15.0,
+        )
+        expected_net = result["revenue_opp"] - result["labor_cost"]
+        assert result["net_roi"] == pytest.approx(expected_net, abs=0.01)
+
+
+# ===========================================================================
+# 6. Integration — run_for_property() with mocked DB
+# ===========================================================================
+
+class TestRunForProperty:
+    """AC 6, 8: ROI fields written back to anomaly rows; idempotency."""
+
+    @pytest.fixture
+    def property_id(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    def _make_db_mock(
+        self,
+        property_id: uuid.UUID,
+        anomaly_rows: list,
+        avg_spend: float = DEFAULT_AVG_SPEND_PER_COVER,
+        hourly_rate: float = DEFAULT_STAFF_HOURLY_RATE,
+    ) -> AsyncMock:
+        """Build a mock AsyncSession that returns the given anomaly rows."""
+        db = AsyncMock()
+        db.commit = AsyncMock()
+
+        # First execute call: property rate lookup
+        rate_result = MagicMock()
+        rate_result.fetchone.return_value = (avg_spend, hourly_rate)
+
+        # Second execute call: anomaly rows
+        anomaly_result = MagicMock()
+        anomaly_result.fetchall.return_value = anomaly_rows
+
+        # Subsequent UPDATE calls return None
+        update_result = MagicMock()
+        update_result.fetchone.return_value = None
+
+        db.execute = AsyncMock(
+            side_effect=[rate_result, anomaly_result] + [update_result] * len(anomaly_rows)
+        )
+        return db
+
+    @pytest.mark.asyncio
+    async def test_roi_fields_written_for_surge(self, svc, property_id):
+        """ROI fields (revenue_opp, labor_cost, net_roi) are written to DB."""
+        # Row format: (id, direction, deviation_pct, expected_demand, baseline_demand)
+        anomaly_id = str(uuid.uuid4())
+        rows = [(anomaly_id, "surge", 25.0, 1100.0, 1000.0)]
+        db = self._make_db_mock(property_id, rows)
+
+        await svc.run_for_property(db, property_id)
+
+        db.commit.assert_called_once()
+        # 3 execute calls: rate lookup + anomaly fetch + 1 update
+        assert db.execute.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_status_set_roi_positive_when_net_positive(self, svc, property_id):
+        """Status is set to 'roi_positive' when net_roi > 0."""
+        anomaly_id = str(uuid.uuid4())
+        rows = [(anomaly_id, "surge", 25.0, 1100.0, 1000.0)]
+        db = self._make_db_mock(property_id, rows)
+
+        await svc.run_for_property(db, property_id)
+
+        # Inspect the UPDATE call params
+        update_call = db.execute.call_args_list[2]
+        params = update_call[0][1]  # positional args: (text_stmt, params)
+        assert params["status"] == "roi_positive"
+
+    @pytest.mark.asyncio
+    async def test_status_remains_detected_when_net_nonpositive(
+        self, svc, property_id
+    ):
+        """Status stays 'detected' when net_roi <= 0 (micro-surge)."""
+        anomaly_id = str(uuid.uuid4())
+        # 1 extra cover × 0.7 × £40 = £28 revenue; 1 head × £14 × 4 = £56 → net = -28
+        rows = [(anomaly_id, "surge", 25.0, 1001.0, 1000.0)]
+        db = self._make_db_mock(property_id, rows)
+
+        await svc.run_for_property(db, property_id)
+
+        update_call = db.execute.call_args_list[2]
+        params = update_call[0][1]
+        assert params["status"] == "detected"
+
+    @pytest.mark.asyncio
+    async def test_no_update_when_no_detected_anomalies(self, svc, property_id):
+        """When no 'detected' anomalies exist, no UPDATE is executed."""
+        db = self._make_db_mock(property_id, [])
+        # Anomaly fetch returns empty; execute is called only twice (rate + fetch)
+        updated = await svc.run_for_property(db, property_id)
+        assert updated == 0
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotency_reruns_update_fields(self, svc, property_id):
+        """Re-running run_for_property on same data issues UPDATE (not INSERT)."""
+        anomaly_id = str(uuid.uuid4())
+        rows = [(anomaly_id, "surge", 25.0, 1100.0, 1000.0)]
+
+        # First run
+        db1 = self._make_db_mock(property_id, rows)
+        count1 = await svc.run_for_property(db1, property_id)
+
+        # Second run — same anomaly row still in 'detected' (test mock)
+        db2 = self._make_db_mock(property_id, rows)
+        count2 = await svc.run_for_property(db2, property_id)
+
+        assert count1 == 1
+        assert count2 == 1  # idempotent: updates 1 row again (no duplicate)
+
+    @pytest.mark.asyncio
+    async def test_lull_anomaly_net_roi_is_zero(self, svc, property_id):
+        """Lull anomaly rows get roi = 0/0/0 and status stays 'detected'."""
+        anomaly_id = str(uuid.uuid4())
+        rows = [(anomaly_id, "lull", -30.0, 700.0, 1000.0)]
+        db = self._make_db_mock(property_id, rows)
+
+        await svc.run_for_property(db, property_id)
+
+        update_call = db.execute.call_args_list[2]
+        params = update_call[0][1]
+        assert params["net_roi"] == 0.0
+        assert params["status"] == "detected"
+
+    @pytest.mark.asyncio
+    async def test_uses_property_rate_overrides(self, svc, property_id):
+        """Property-specific rates are used when available."""
+        anomaly_id = str(uuid.uuid4())
+        rows = [(anomaly_id, "surge", 25.0, 1100.0, 1000.0)]
+        # Custom rates: £60 / h, £20 / staff-hour
+        db = self._make_db_mock(property_id, rows, avg_spend=60.0, hourly_rate=20.0)
+
+        await svc.run_for_property(db, property_id)
+
+        update_call = db.execute.call_args_list[2]
+        params = update_call[0][1]
+        # revenue_opp = 0.7 × 100 × 60 = £4200; labor = 1 × 20 × 4 = £80
+        assert params["revenue_opp"] == pytest.approx(4200.0, abs=0.01)
+        assert params["labor_cost"] == pytest.approx(80.0, abs=0.01)
+
+
+# ===========================================================================
+# 7. Integration — POST /api/v1/anomalies/roi returns 202
+# ===========================================================================
+
+class TestROIRoute:
+    """AC 10: POST /api/v1/anomalies/roi → 202 Accepted."""
+
+    @pytest.fixture
+    def app_client(self) -> TestClient:
+        from fastapi import FastAPI
+        from app.api.routes.anomalies import router
+        from app.core.error_handlers import problem_details_handler
+        from fastapi import HTTPException
+
+        app = FastAPI()
+        app.add_exception_handler(HTTPException, problem_details_handler)
+
+        # Override auth and DB dependencies
+        from app.core.security import get_current_user
+        from app.db.session import get_db
+
+        async def _fake_user():
+            return {"id": str(uuid.uuid4()), "email": "test@aetherix.io"}
+
+        async def _fake_db():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_current_user] = _fake_user
+        app.dependency_overrides[get_db] = _fake_db
+        app.include_router(router, prefix="/api/v1")
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_roi_route_returns_202(self, app_client: TestClient):
+        """POST /api/v1/anomalies/roi returns HTTP 202 with expected body."""
+        with patch(
+            "app.services.roi_calculator.ROICalculatorService.run_full_scan",
+            new_callable=AsyncMock,
+        ):
+            response = app_client.post("/api/v1/anomalies/roi")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["message"] == "ROI calculation triggered"
+
+    def test_roi_route_body_contains_triggered_by(self, app_client: TestClient):
+        """Response body includes triggeredBy (camelCase) from current user."""
+        with patch(
+            "app.services.roi_calculator.ROICalculatorService.run_full_scan",
+            new_callable=AsyncMock,
+        ):
+            response = app_client.post("/api/v1/anomalies/roi")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert "triggeredBy" in body
+
+
+# ===========================================================================
+# 8. Unit — auto-chain worker smoke test (AC 9)
+# ===========================================================================
+
+class TestWorkerChain:
+    """AC 9: ROI calculation is chained in anomaly_scan worker."""
+
+    def test_worker_imports_roi_calculator(self):
+        """The anomaly_scan worker module imports ROICalculatorService."""
+        import app.workers.anomaly_scan as worker_module
+        assert hasattr(worker_module, "ROICalculatorService") or hasattr(
+            worker_module, "_roi_service"
+        ), "Worker must reference ROICalculatorService"
+
+    def test_worker_has_roi_service_instance(self):
+        """The worker module holds a _roi_service instance."""
+        import app.workers.anomaly_scan as worker_module
+        assert hasattr(
+            worker_module, "_roi_service"
+        ), "_roi_service not found in anomaly_scan worker"
+
+    @pytest.mark.asyncio
+    async def test_worker_job_chains_roi(self):
+        """_run_anomaly_scan_job calls both anomaly scan and ROI scan."""
+        from app.workers.anomaly_scan import _run_anomaly_scan_job
+
+        with patch(
+            "app.workers.anomaly_scan._service.run_full_scan",
+            new_callable=AsyncMock,
+        ) as mock_scan, patch(
+            "app.workers.anomaly_scan._roi_service.run_full_scan",
+            new_callable=AsyncMock,
+        ) as mock_roi, patch(
+            "app.workers.anomaly_scan.AsyncSessionLocal",
+        ) as mock_session_factory:
+            mock_session = AsyncMock()
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+            mock_session_factory.return_value = mock_session
+
+            await _run_anomaly_scan_job()
+
+        mock_scan.assert_called_once()
+        mock_roi.assert_called_once()

--- a/supabase/migrations/20260323100000_add_roi_config_to_properties.sql
+++ b/supabase/migrations/20260323100000_add_roi_config_to_properties.sql
@@ -1,0 +1,34 @@
+-- Story 3.3b: Calculate Financial ROI for Detected Anomalies
+-- Migration: add_roi_config_to_properties
+-- AC: 7 — Configurable Rates per property with system-level defaults
+
+-- Add ROI rate columns to properties table if it exists.
+-- These columns are nullable so existing rows remain valid;
+-- the application falls back to DEFAULT_AVG_SPEND_PER_COVER (£40)
+-- and DEFAULT_STAFF_HOURLY_RATE (£14) when NULL.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'properties'
+    ) THEN
+        -- avg_spend_per_cover: average revenue per cover for this property (£)
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'properties' AND column_name = 'avg_spend_per_cover'
+        ) THEN
+            ALTER TABLE properties
+                ADD COLUMN avg_spend_per_cover NUMERIC(8, 2) DEFAULT 40.00;
+        END IF;
+
+        -- staff_hourly_rate: hourly cost per additional staff member (£)
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'properties' AND column_name = 'staff_hourly_rate'
+        ) THEN
+            ALTER TABLE properties
+                ADD COLUMN staff_hourly_rate NUMERIC(8, 2) DEFAULT 14.00;
+        END IF;
+    END IF;
+END $$;


### PR DESCRIPTION
Implements Story 3.3b on top of Story 3.3a (anomaly detection):

- supabase/migrations/20260323100000_add_roi_config_to_properties.sql Adds avg_spend_per_cover (£40 default) and staff_hourly_rate (£14 default) columns to the properties table via idempotent DO $$ block.

- backend/app/core/config.py  (new) DEFAULT_AVG_SPEND_PER_COVER = 40.0, DEFAULT_STAFF_HOURLY_RATE = 14.0, DEFAULT_CAPTATION_RATE = 0.7 — system-level defaults (AC 7).

- backend/app/services/roi_calculator.py  (new) ROICalculatorService with: • recommended_headcount(deviation_pct) — headcount scale table • calculate_for_anomaly() — revenue_opp / labor_cost / net_roi formulas • run_for_property(db, property_id) — fetch 'detected' anomalies, compute, write-back roi_* fields, promote status to 'roi_positive' when net > 0 • run_full_scan(db) — asyncio.gather across all active properties Lull anomalies get zeros for all ROI fields (no staffing action needed). Fully idempotent: re-running UPDATE existing rows, no duplicates (AC 8).

- backend/app/db/models.py RestaurantProfile: added avg_spend_per_cover, staff_hourly_rate columns. (DemandAnomaly roi_* columns were already added in Story 3.3a.)

- backend/app/schemas/anomalies.py Added ROICalculationResponse schema for POST /roi endpoint.

- backend/app/api/routes/anomalies.py Appended POST /api/v1/anomalies/roi → 202 Accepted (AC 10).

- backend/app/workers/anomaly_scan.py Chained _roi_service.run_full_scan() immediately after anomaly scan in _run_anomaly_scan_job (AC 9: auto-chain after each scan cycle).

- backend/tests/test_roi_calculator.py  (new — 27 tests) Covers: headcount scale ×5, revenue opportunity ×3, labor cost ×3, lull handling ×1, net ROI & status ×3, run_for_property ×7, POST /roi route ×2, worker chain smoke tests ×3. All 27 new tests pass; all 32 existing 3.3a tests continue to pass.

https://claude.ai/code/session_01V3ZyDup4m5HJHBkxoxBuEc