### PR TITLE
feat(HOS-37): Activate Claude MCP pipeline — POST /predict

### DIFF
--- a/backend/app/api/routes/predictions.py
+++ b/backend/app/api/routes/predictions.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from typing import Dict, Any, Optional
 from datetime import date
 from app.services.aetherix_engine import AetherixEngine
@@ -10,6 +11,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter(prefix="/predictions", tags=["predictions"])
 engine = AetherixEngine()
+
+
+# ---------------------------------------------------------------------------
+# Schemas for POST /predict (MCP-callable, agent-facing)
+# ---------------------------------------------------------------------------
+
+class PredictRequest(BaseModel):
+    """Input for the agent-callable predict endpoint."""
+    hotel_id: str = Field(..., description="Tenant / property identifier")
+    target_date: date = Field(..., description="Date to forecast (ISO-8601)")
+    service_type: str = Field("dinner", description="Meal service type: breakfast | lunch | dinner")
+    context: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Optional external context: "
+            "{weather: {condition, temp}, events: [...], occupancy: 0.0-1.0}"
+        ),
+    )
+
+
+class PredictResponse(BaseModel):
+    """Structured output — stable schema for Agent SEO / MCP callers."""
+    hotel_id: str
+    target_date: str
+    service_type: str
+    predicted_covers: int
+    confidence: float
+    range_min: int
+    range_max: int
+    reasoning_summary: str
+    confidence_factors: list
+    claude_used: bool
+    staffing_recommendation: Dict[str, Any]
 
 @router.get("/current")
 async def get_property_prediction(
@@ -47,3 +81,50 @@ async def get_property_prediction(
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/predict", response_model=PredictResponse, summary="Forecast F&B covers (MCP-callable)")
+async def predict(body: PredictRequest):
+    """MCP-callable endpoint: given a hotel_id and date, returns a structured
+    demand forecast with LLM reasoning (Claude Sonnet) or a heuristic fallback
+    when ANTHROPIC_API_KEY is absent.
+
+    Designed for agent-to-agent use (HOS-37 / HOS-71 MCP Server). No JWT auth
+    required — authenticate at the infrastructure layer (API key header, VPN, etc.)
+    when exposing publicly.
+
+    Schema stability: BREAKING changes require a version bump (Agent SEO policy).
+    """
+    ctx = body.context or {
+        "weather": {"condition": "Unknown", "temp": None},
+        "events": [],
+        "occupancy": None,
+    }
+
+    try:
+        result = await engine.get_forecast(
+            body.hotel_id, body.target_date, body.service_type, ctx
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    pred = result["prediction"]
+    # Use reasoning_detail (full dict) when available, fall back to the summary string.
+    reasoning_detail = result.get("reasoning_detail", {})
+    summary = reasoning_detail.get("summary") or str(result.get("reasoning", ""))
+    confidence_factors = reasoning_detail.get("confidence_factors", [])
+    claude_used = reasoning_detail.get("claude_used", False)
+
+    return PredictResponse(
+        hotel_id=body.hotel_id,
+        target_date=result.get("date", body.target_date.isoformat()),
+        service_type=result.get("service_type", body.service_type),
+        predicted_covers=pred.get("covers", pred.get("predicted_covers", 0)),
+        confidence=pred.get("confidence", 0.0),
+        range_min=pred.get("interval", [pred.get("covers", 0), pred.get("covers", 0)])[0],
+        range_max=pred.get("interval", [pred.get("covers", 0), pred.get("covers", 0)])[1],
+        reasoning_summary=summary,
+        confidence_factors=confidence_factors,
+        claude_used=claude_used,
+        staffing_recommendation=result.get("staffing_recommendation", {}),
+    )

--- a/backend/app/services/aetherix_engine.py
+++ b/backend/app/services/aetherix_engine.py
@@ -52,7 +52,10 @@ class AetherixEngine:
                 "covers": predicted_covers,
                 "confidence": confidence
             },
+            # reasoning["summary"] kept for backward compat (WhatsApp service etc.)
             "reasoning": reasoning["summary"],
+            # full reasoning dict for structured consumers (POST /predict, MCP)
+            "reasoning_detail": reasoning,
             "staffing_recommendation": staffing,
             "historical_patterns": patterns
         }

--- a/backend/app/services/reasoning_service.py
+++ b/backend/app/services/reasoning_service.py
@@ -25,13 +25,15 @@ class ReasoningService:
     ) -> Dict:
         """Calls Claude to explain the prediction rationale."""
         if not self.claude:
-            return {"summary": "Claude API key missing. Numerical forecast only.", "confidence_factors": []}
+            return self._heuristic_explanation(
+                predicted_covers, confidence, target_date, service_type, context, similar_patterns
+            )
 
         prompt = self._build_prompt(predicted_covers, confidence, target_date, service_type, context, similar_patterns, cognitive_context)
         
         try:
             message = await self.claude.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-sonnet-4-6",
                 max_tokens=300,
                 temperature=0.3,
                 messages=[{"role": "user", "content": prompt}]
@@ -39,7 +41,8 @@ class ReasoningService:
             explanation = message.content[0].text.strip()
             return {
                 "summary": explanation,
-                "confidence_factors": self._extract_factors(context, similar_patterns)
+                "confidence_factors": self._extract_factors(context, similar_patterns),
+                "claude_used": True,
             }
         except Exception as e:
             import asyncio
@@ -49,7 +52,13 @@ class ReasoningService:
                 detail=f"Exception: {e}\nDate: {target_date} | Service: {service_type} | Covers: {predicted_covers}",
                 tags=["claude", "reasoning"],
             ))
-            return {"summary": f"Reasoning failed: {str(e)}", "confidence_factors": []}
+            return {
+                **self._heuristic_explanation(
+                    predicted_covers, confidence, target_date, service_type, context, similar_patterns
+                ),
+                "claude_used": False,
+                "fallback_reason": str(e),
+            }
 
     def _build_prompt(self, predicted, confidence, dt, svc, context, patterns, cognitive_context) -> str:
         patterns_text = ""
@@ -87,3 +96,60 @@ Keep it actionable for a manager.
         if context.get('events'): factors.append(f"{len(context['events'])} events nearby")
         if patterns: factors.append("Historical pattern matching")
         return factors
+
+    def _heuristic_explanation(
+        self,
+        predicted: int,
+        confidence: float,
+        dt: date,
+        svc: str,
+        context: Dict,
+        patterns: List[Dict],
+    ) -> Dict:
+        """Rule-based explanation used when Claude is unavailable.
+
+        Produces a human-readable summary using only the data already in hand —
+        no LLM call required. This ensures the /predict endpoint always returns
+        an actionable reasoning block.
+        """
+        day_name = dt.strftime("%A")
+        conf_pct = int(confidence * 100)
+
+        # Pattern anchor sentence
+        if patterns:
+            best = patterns[0]
+            payload = best.get("payload", best)
+            hist_covers = payload.get("actual_covers", payload.get("covers", "?"))
+            hist_date = payload.get("date", "a similar past date")
+            pattern_note = (
+                f"Historical data shows {hist_covers} covers on {hist_date} "
+                f"under similar conditions."
+            )
+        else:
+            pattern_note = "No close historical pattern available for direct comparison."
+
+        # Context modifiers
+        weather = context.get("weather", {})
+        weather_note = ""
+        if weather.get("condition"):
+            weather_note = f" Current weather is {weather['condition']}."
+
+        events = context.get("events", [])
+        event_note = ""
+        if events:
+            event_note = f" {len(events)} nearby event(s) may drive additional demand."
+
+        occ = context.get("occupancy")
+        occ_note = f" Hotel occupancy is at {int(occ * 100)}%." if occ else ""
+
+        summary = (
+            f"Prophet forecasts {predicted} covers for {svc} on {day_name} "
+            f"with {conf_pct}% confidence. "
+            f"{pattern_note}{weather_note}{event_note}{occ_note}"
+        ).strip()
+
+        return {
+            "summary": summary,
+            "confidence_factors": self._extract_factors(context, patterns),
+            "claude_used": False,
+        }


### PR DESCRIPTION
Implements HOS-37: activate the Claude path via ANTHROPIC_API_KEY with heuristic fallback when the key is absent.

Changes:

reasoning_service.py
- Upgrade model: claude-3-5-haiku → claude-sonnet-4-6 (per CLAUDE.md)
- Add claude_used flag to all return paths (True/False)
- Replace "Claude API key missing" stub with _heuristic_explanation(): a data-driven Prophet + pattern + context summary always returned, never an empty/useless fallback
- On Claude API error: heuristic kicks in automatically

aetherix_engine.py
- Add reasoning_detail key to get_forecast() result dict (full reasoning dict alongside the existing reasoning summary string for backward compat)

predictions.py — POST /api/v1/predictions/predict (MCP-callable)
- New PredictRequest / PredictResponse Pydantic schemas
- No JWT auth — designed for agent-to-agent calls (HOS-71 MCP Server)
- Stable response schema: hotel_id, target_date, service_type, predicted_covers, confidence, range_min/max, reasoning_summary, confidence_factors, claude_used, staffing_recommendation
- Schema stability = 0 breaking changes per sprint (Agent SEO policy)

https://claude.ai/code/session_01V3ZyDup4m5HJHBkxoxBuEc